### PR TITLE
Multiple auth settings for a single Api definition

### DIFF
--- a/api_defintitions.go
+++ b/api_defintitions.go
@@ -206,7 +206,11 @@ type APIDefinition struct {
 	} `bson:"oauth_meta" json:"oauth_meta"`
 	Auth struct {
 		UseParam       bool   `mapstructure:"use_param" bson:"use_param" json:"use_param"`
+		ParamName      string `mapstructure:"param_name" bson:"param_name" json:"param_name"`
 		UseCookie      bool   `mapstructure:"use_cookie" bson:"use_cookie" json:"use_cookie"`
+		CookieName     string `mapstructure:"cookie_name" bson:"cookie_name" json:"cookie_name"`
+		CookieHashKey  []byte `mapstructure:"cookie_hash_key" bson:"cookie_hash_key" json:"cookie_hash_key"`
+		CookieBlockKey []byte `mapstructure:"cookie_block_key" bson:"cookie_block_key" json:"cookie_block_key"`
 		AuthHeaderName string `mapstructure:"auth_header_name" bson:"auth_header_name" json:"auth_header_name"`
 	} `bson:"auth" json:"auth"`
 	UseBasicAuth            bool                 `bson:"use_basic_auth" json:"use_basic_auth"`

--- a/api_defintitions.go
+++ b/api_defintitions.go
@@ -209,8 +209,6 @@ type APIDefinition struct {
 		ParamName      string `mapstructure:"param_name" bson:"param_name" json:"param_name"`
 		UseCookie      bool   `mapstructure:"use_cookie" bson:"use_cookie" json:"use_cookie"`
 		CookieName     string `mapstructure:"cookie_name" bson:"cookie_name" json:"cookie_name"`
-		CookieHashKey  []byte `mapstructure:"cookie_hash_key" bson:"cookie_hash_key" json:"cookie_hash_key"`
-		CookieBlockKey []byte `mapstructure:"cookie_block_key" bson:"cookie_block_key" json:"cookie_block_key"`
 		AuthHeaderName string `mapstructure:"auth_header_name" bson:"auth_header_name" json:"auth_header_name"`
 	} `bson:"auth" json:"auth"`
 	UseBasicAuth            bool                 `bson:"use_basic_auth" json:"use_basic_auth"`


### PR DESCRIPTION
This change allows multiple authentication types for a single API definition. I am currently working on a Pull request to have Tyk's `middleware_auth_key.go` check for the `AuthHeaderName` first, then it will check the url parameter (if `UseParam == true` or `ParamName` has a value) and lastly it will check the named cookie (if `UseCookie == true` or `CookieName` has a value).

I removed the encrypted cookie feature because my project currently does not need this anymore and it makes this change smaller and easier to test.

I am creating this pull request now so - when I send you the pull request for Tyk - it depend on this instead of my fork.

This change is backwards compatible because the UseParam and UseCookie flags still exist in the spec and behavior doesn't change if one sets UseParam to true but does not define a value for ParamName (ditto for the cookie). My changes to Tyk will make this clear.

Please let me know if you need any additional info. Have you considered using Godep for tyk?
