### PR TITLE
Merge tykcommon-logger into this repo

### DIFF
--- a/log.go
+++ b/log.go
@@ -1,0 +1,29 @@
+package tykcommon
+
+import (
+	"os"
+	"strings"
+
+	"github.com/TykTechnologies/logrus"
+	prefixed "github.com/TykTechnologies/logrus-prefixed-formatter"
+)
+
+var log = logrus.New()
+
+func init() {
+	log.Formatter = new(prefixed.TextFormatter)
+}
+
+func GetLogger() *logrus.Logger {
+	switch strings.ToLower(os.Getenv("TYK_LOGLEVEL")) {
+	case "error":
+		log.Level = logrus.ErrorLevel
+	case "warn":
+		log.Level = logrus.WarnLevel
+	case "debug":
+		log.Level = logrus.DebugLevel
+	default:
+		log.Level = logrus.InfoLevel
+	}
+	return log
+}

--- a/tykcommon.go
+++ b/tykcommon.go
@@ -1,7 +1,0 @@
-package tykcommon
-
-import (
-	"github.com/TykTechnologies/logrus"
-)
-
-var log = logrus.New()


### PR DESCRIPTION
Since both used 'var log' in the root package, keep it the same way. The
variable in this package was only used internally, so the change is
safe.

Fixes TykTechnologies/tyk#389.